### PR TITLE
Super sample blended images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ tmp
 *.mp4
 
 .vscode/launch.json
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 tmp
 *.mp4
 
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -3,28 +3,29 @@
 This script aims to help to create zoom out/in videos from the set of images (generated, for example, with [Midjourney 5.2 zoom out feature](https://docs.midjourney.com/docs/zoom-out) or other AI tools like Stable Diffusion or Photoshop) in a few minutes (depending on the number of images used of course).
 
 Features:
+
 - The script uses a correct interpolation for zooming that doesn't cause the effect of speeding up/and slowing down, which is noticeable in some zoom videos.
 - It implements some basic image blending, so the transitions between images seem to be more smooth.
 - It allows to set video duration, resolution, frame rate, direction of zoom, and easing.
 - It can optionally add audio to the generated video.
 
 Limitations:
+
 - Currently, the zoom factor/ratio between all the images needs to be the same.
 - At the moment, the images need to be perfectly centered (Midjourney 5.2 zoom out feature from time to time shifts the image that is zoomed out, and such images might not look good in the video).
 
-
 I create it for myself to make experimentation with Midjourney easier for me. I've might miss some possible use cases, so if something is not working for you, or you would like to have some feature, please let me know I will try to fix/improve it. Contributions are welcome, just open a PR.
-
 
 ## Usage
 
-To use the script, you need to have Python installed on your machine. 
-You can download it [here](https://www.python.org/downloads/) if you are using Windows. 
+To use the script, you need to have Python installed on your machine.
+You can download it [here](https://www.python.org/downloads/) if you are using Windows.
 MacOS and Linux users should have Python installed by default.
 
 1. [Download this repository](https://github.com/mwydmuch/ZoomVideoComposer/archive/refs/tags/0.3.2.zip), unpack it, and open the terminal/command line window in the root of the repository.
 
 2. Install the required packages by running the following command in the terminal/cmd window:
+
 ```
 pip install -r requirements.txt
 ```
@@ -73,6 +74,11 @@ Options:
   -s, --resampling [nearest|box|bilinear|hamming|bicubic|lanczos]
                                   Resampling technique to use when resizing
                                   images.  [default: lanczos]
+  -ss, --supersample FLOAT        Supersamples (scales) the images by this
+                                  factor. A value > 1 will increase the
+                                  smoothness of the animation, but will also
+                                  increase the duration of the rendering.
+                                  [default: 1]
   -m, --margin FLOAT              Size of the margin to cut from the edges of
                                   each image for better blending with the
                                   next/previous image. Values > 1 are
@@ -103,7 +109,6 @@ Options:
   --help                          Show this message and exit.
 ```
 
-
 ## Example of usage
 
 Run in the root directory of the repository to generate an example video from the images in the `example` directory, a duration of 20 seconds that first zooms out and then zooms back in. The video will be saved in the `example_output.mp4` file.
@@ -118,13 +123,12 @@ This example takes around 3 minutes to run on my Macbook Air M2. It can be speed
 python zoom_video_composer.py example -o example_output_faster.mp4 -d 20 -r outin -e easeInOutSine -f 10 -w 512 -h 512 -s bilinear
 ```
 
-
 ## Video tutorial and Google Colab for online use online
+
 (Thanks to [u/OkRub6877](https://www.reddit.com/user/OkRub6877/))
 
 You can watch the video tutorial on the tool [here](https://www.youtube.com/watch?v=nIJV_c-hKuw).
 And use it online (without installing anything on your machine) using this [Google Colab](https://colab.research.google.com/drive/1lp_GF9Q8x5ckY7yQIA9zo37g-1TUGQ1T?usp=sharing).
-
 
 ## Tips for generating proper images with Midjourney
 
@@ -133,20 +137,20 @@ And use it online (without installing anything on your machine) using this [Goog
 - Sometimes, Midjourney slightly changes the objects' position in the center when zooming out. It's recommended to avoid that by carefully selecting the images. It can also be fixed manually before running the script. See [Fix image shift](./guides/fix_image_shift.md)
 - **`Zoom Out 1.5x` button in Midjourney is currently bugged and uses another zoom factor than `--zoom 1.5` prompt argument. To create an animation from images created with this button, use `-z 1.3333` argument for the script.**
 
-
 ## Tips on editing the images
 
-The script stack images on top of each other and blends them together. 
-The most zoomed-in images are always on top of less zoomed-in images, 
+The script stack images on top of each other and blends them together.
+The most zoomed-in images are always on top of less zoomed-in images,
 so if you want to modify something on the images manually, you can do it only on the most zoomed-in image.
 
-
 ## Tips on how to generate images with Stable Diffusion or Photoshop
+
 (Thanks to [u/ObiWanCanShowMe](https://www.reddit.com/user/ObiWanCanShowMe/))
 
 ### Stable Diffusion
 
 To create a zoom out image in Stable Diffusion, you can:
+
 1. Create an image.
 2. Outpaint to a multiplier of canvas size (e.g., 2x)
 3. Resize down to the original size.
@@ -156,12 +160,12 @@ Repeat until you get the desired number of images.
 ### Photoshop
 
 You can also create proper images using Photoshop:
+
 1. Create an image.
 2. Resize an image to a multiplier of canvas size (e.g., 2x) and use generative fill on the empty space
 3. Resize down to the original size.
 
 Repeat until you get the desired number of images.
-
 
 ## Animations created with this script
 
@@ -171,14 +175,11 @@ Repeat until you get the desired number of images.
 - [Black and white (and 3 more)](https://www.reddit.com/r/midjourney/comments/14x2l6a/zoom_out_animations_collection/)
 - [Platypus at the end of the world (and 2 more)](https://www.reddit.com/r/midjourney/comments/14yv90n/zoom_out_animations_lt35_universe_trip_down_the/)
 
-
 Add your animations here by creating a pull request.
-
 
 ## Projects using Video
 
 - [GoAPI Midjourney ZoomVideo Generator](https://huggingface.co/spaces/GoAPI/Midjourney-zoom-video-generator-GoAPI)
-
 
 ## TODOs
 

--- a/helpers.py
+++ b/helpers.py
@@ -312,14 +312,9 @@ def blend_images(images, margin, zoom, resampling_func):
     return images
 
 
-def resize_all_images(images, resize_factor, resampling_func):
-    if resize_factor == 1.0:
-        return images
-
-    for i in range(0, len(images)):
-        image = images[i]
-        image = image.resize_scale(resize_factor, resampling_func)
-        images[i] = image
+def resize_images(images, resize_factor, resampling_func):
+    for i, image in enumerate(images):
+        images[i] = image.resize_scale(resize_factor, resampling_func)
 
     return images
 

--- a/helpers.py
+++ b/helpers.py
@@ -305,16 +305,18 @@ def blend_images(images, margin, zoom, resampling_func):
 
     return images
 
-def resize_all_image(images, resize_factor, resampling_func):
+
+def resize_all_images(images, resize_factor, resampling_func):
     if isclose(resize_factor, 1.0):
         return images
-    
-    for i in range(0, images):
+
+    for i in range(0, len(images)):
         image = images[i]
-        image = image.resize((image.width * resize_factor, image.height * resize_factor), resampling_func)
-        images[i] = Image
+        image = image.resize_scale(resize_factor, resampling_func)
+        images[i] = image
 
     return images
+
 
 def process_frame(
     i,

--- a/helpers.py
+++ b/helpers.py
@@ -1,5 +1,5 @@
 import os
-from math import cos, pi, sin, pow, ceil
+from math import cos, pi, sin, pow, ceil, isclose
 
 import cv2
 import gradio as gr
@@ -305,6 +305,16 @@ def blend_images(images, margin, zoom, resampling_func):
 
     return images
 
+def resize_all_image(images, resize_factor, resampling_func):
+    if isclose(resize_factor, 1.0):
+        return images
+    
+    for i in range(0, images):
+        image = images[i]
+        image = image.resize((image.width * resize_factor, image.height * resize_factor), resampling_func)
+        images[i] = Image
+
+    return images
 
 def process_frame(
     i,
@@ -360,7 +370,7 @@ def create_video_clip(output_path, fps, num_frames, tmp_dir_hash, audio_path, th
         os.path.join(tmp_dir_hash, f"{i:06d}.png") for i in range(num_frames)
     ]
     video_clip = ImageSequenceClip(image_files, fps=fps)
-    video_write_kwargs = {"codec": "libx264", "threads": threads}
+    video_write_kwargs = {"codec": "libx264", "threads": threads, "bitrate": "8M"}
 
     # Add audio
     if audio_path:
@@ -374,7 +384,7 @@ def create_video_clip(output_path, fps, num_frames, tmp_dir_hash, audio_path, th
         logger=TqdmProgressBarLogger(
             bars={
                 "t": {
-                    "title": "Writting the movie file",
+                    "title": "Writing the movie file",
                     "total": num_frames,
                     "message": None,
                     "index": -1,

--- a/helpers.py
+++ b/helpers.py
@@ -1,5 +1,5 @@
 import os
-from math import cos, pi, sin, pow, ceil, isclose
+from math import cos, pi, sin, pow, ceil
 
 import cv2
 import gradio as gr
@@ -100,6 +100,7 @@ class ImagePIL(ImageWrapper):
 
 # Easing and resampling functions
 
+
 # Gennerat family of power-based easing functions
 def get_ease_pow_in(power, **kwargs):
     return lambda x: pow(x, power)
@@ -118,19 +119,23 @@ def get_ease_pow_in_out(power, **kwargs):
 
 
 # Returns an linear easing function with in and out ease
-# This is useful for very long animations 
+# This is useful for very long animations
 # where you want a steady zoom speed but still start and stop smoothly.
 def get_linear_with_in_out_ease(ease_duration, **kwargs):
     # fraction defines both the x and y of the 'square' in which the easing takes place
     ease_duration_scale = 1 / ease_duration
+
     def linear_ease_in_out(x):
         if x < ease_duration:
             return (x * ease_duration_scale) ** 2 / ease_duration_scale / 2
         elif x > (1 - ease_duration):
             return 1 - ((1 - x) * ease_duration_scale) ** 2 / ease_duration_scale / 2
         else:
-            return (x - ease_duration) * (1 - ease_duration) / (1 - 2 * ease_duration) + ease_duration / 2
-    return linear_ease_in_out      
+            return (x - ease_duration) * (1 - ease_duration) / (
+                1 - 2 * ease_duration
+            ) + ease_duration / 2
+
+    return linear_ease_in_out
 
 
 EASING_FUNCTIONS = {
@@ -152,6 +157,7 @@ EASING_FUNCTIONS = {
 DEFAULT_EASING_KEY = "easeInOutSine"
 DEFAULT_EASING_POWER = 1.5
 DEFAULT_EASE_DURATION = 0.02
+
 
 def get_easing_function(easing, power, ease_duration):
     easing_func = EASING_FUNCTIONS.get(easing, None)
@@ -307,7 +313,7 @@ def blend_images(images, margin, zoom, resampling_func):
 
 
 def resize_all_images(images, resize_factor, resampling_func):
-    if isclose(resize_factor, 1.0):
+    if resize_factor == 1.0:
         return images
 
     for i in range(0, len(images)):
@@ -372,7 +378,7 @@ def create_video_clip(output_path, fps, num_frames, tmp_dir_hash, audio_path, th
         os.path.join(tmp_dir_hash, f"{i:06d}.png") for i in range(num_frames)
     ]
     video_clip = ImageSequenceClip(image_files, fps=fps)
-    video_write_kwargs = {"codec": "libx264", "threads": threads, "bitrate": "8M"}
+    video_write_kwargs = {"codec": "libx264", "threads": threads}
 
     # Add audio
     if audio_path:

--- a/zoom_video_composer.py
+++ b/zoom_video_composer.py
@@ -37,6 +37,7 @@ from helpers import *
 
 VERSION = "0.3.2"
 
+
 @click.command()
 @click.argument(
     "image_paths",
@@ -133,7 +134,7 @@ VERSION = "0.3.2"
 )
 @click.option(
     "-ss",
-    "--supersample",
+    "--super-sampling-factor",
     type=float,
     default=1,
     help="Supersamples (scales) the images by this factor. A value > 1 will increase the smoothness of the animation, but will also increase the duration of the rendering.",
@@ -288,7 +289,7 @@ def zoom_video_composer(
     start_time = time.time()
 
     """Compose a zoom video from multiple provided images."""
-    video_params = f'zoom={zoom}, fps={fps}, dur={duration}, easing={easing}, easing_power={easing_power}, ease_duration={ease_duration}, direction={direction}, resampling={resampling}, margin={margin}, width={width}, height={height}'
+    video_params = f"zoom={zoom}, fps={fps}, dur={duration}, easing={easing}, easing_power={easing_power}, ease_duration={ease_duration}, direction={direction}, resampling={resampling}, margin={margin}, width={width}, height={height}"
     logger(f"Starting zoom video composition with parameters:\n{video_params}")
 
     # Read images
@@ -325,7 +326,7 @@ def zoom_video_composer(
 
     # Super sampling
     logger(f"Super sample factor: {super_sampling_factor}.")
-    images = resize_all_images(images, super_sampling_factor, resampling_func);
+    images = resize_all_images(images, super_sampling_factor, resampling_func)
 
     # Create frames
     n_jobs = threads if threads > 0 else cpu_count() - threads
@@ -357,12 +358,14 @@ def zoom_video_composer(
         ]
         try:
             completed = concurrent.futures.as_completed(futures)
-            for _ in tqdm(range(num_frames - start_frame), desc="Generating the frames"):
+            for _ in tqdm(
+                range(num_frames - start_frame), desc="Generating the frames"
+            ):
                 completed.__next__()
         except KeyboardInterrupt:
             executor.shutdown(wait=False, cancel_futures=True)
             raise
-    
+
     # Images are no longer needed
     del images
 


### PR DESCRIPTION
This improves the issue described here: https://github.com/mwydmuch/ZoomVideoComposer/issues/16

It is currently solved by the suggested method of scaling the images before creating the frames. It seems to fix the issue quite well. The improvement is noticeable at scale factor 2 and I couldn't notice any jitter at all anymore at factor 4. It looks like the render time more or less doubles with each super sample factor step.

*Test render times*
20s clip at 60fps

- supersample 1 (no effect):
94s
https://youtu.be/IGAOZLIjaXY

- supersample 2:
158s
https://youtu.be/p6GayUAnBZ4

- supersample 3:
279s
https://youtu.be/tqZPl2PTa7Y

- supersample 4:
560s
https://youtu.be/ekc9XuGE8bM

- Complete render, at 60fps with supersampling 4.
3368.99s
https://youtu.be/fgu9F1_Gb_o

