### PR TITLE
Option: Preview blend images only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ cython_debug/
 tmp
 *.mp4
 
+.vscode/launch.json
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -166,5 +166,4 @@ cython_debug/
 tmp
 *.mp4
 
-.vscode/launch.json
-.vscode/settings.json
+.vscode

--- a/README.md
+++ b/README.md
@@ -3,28 +3,29 @@
 This script aims to help to create zoom out/in videos from the set of images (generated, for example, with [Midjourney 5.2+ zoom out feature](https://docs.midjourney.com/docs/zoom-out) or other AI tools like Stable Diffusion or Photoshop) in a few minutes (depending on the number of images used of course).
 
 Features:
+
 - The script uses a correct interpolation for zooming that doesn't cause the effect of speeding up/and slowing down, which is noticeable in some zoom videos.
 - It implements some basic image blending, so the transitions between images seem to be more smooth.
 - It allows to set video duration, resolution, frame rate, direction of zoom, and easing.
 - It can optionally add audio to the generated video.
 
 Limitations:
+
 - Currently, the zoom factor/ratio between all the images needs to be the same.
 - At the moment, the images need to be perfectly centered (Midjourney 5.2 zoom out feature from time to time shifts the image that is zoomed out, and such images might not look good in the video).
 
-
 I created it for myself to make experimentation with Midjourney easier for me. I might have missed some possible use cases, so if something is not working for you or you would like to have some feature, please let me know, and I will try to fix/improve it. Contributions are welcome, just open a PR.
-
 
 ## Usage
 
-To use the script, you need to have Python installed on your machine. 
-You can download it [here](https://www.python.org/downloads/) if you are using Windows. 
+To use the script, you need to have Python installed on your machine.
+You can download it [here](https://www.python.org/downloads/) if you are using Windows.
 MacOS and Linux users should have Python installed by default.
 
 1. [Download this repository](https://github.com/mwydmuch/ZoomVideoComposer/archive/refs/tags/0.3.2.zip), unpack it, and open the terminal/command line window in the root of the repository.
 
 2. Install the required packages by running the following command in the terminal/cmd window:
+
 ```
 pip install -r requirements.txt
 ```
@@ -100,9 +101,12 @@ Options:
                                   [default: cv2]
   --resume                        Resume generation of the video.  [default:
                                   False]
+  --blend-images-only             Stops after blending the images. Inspecting
+                                  the blend images is useful to detect any
+                                  image-shifts or other artefacts before
+                                  generating the video. [default: False]
   --help                          Show this message and exit.
 ```
-
 
 ## Example of usage
 
@@ -118,13 +122,12 @@ This example takes around 3 minutes to run on my Macbook Air M2. It can be speed
 python zoom_video_composer.py example -o example_output_faster.mp4 -d 20 -r outin -e easeInOutSine -f 10 -w 512 -h 512 -s bilinear
 ```
 
-
 ## Video tutorial and Google Colab for online use online
+
 (Thanks to [u/OkRub6877](https://www.reddit.com/user/OkRub6877/))
 
 You can watch the video tutorial on the tool [here](https://www.youtube.com/watch?v=nIJV_c-hKuw).
 And use it online (without installing anything on your machine) using this [Google Colab](https://colab.research.google.com/drive/1lp_GF9Q8x5ckY7yQIA9zo37g-1TUGQ1T?usp=sharing).
-
 
 ## Tips for generating proper images with Midjourney
 
@@ -133,20 +136,20 @@ And use it online (without installing anything on your machine) using this [Goog
 - Sometimes, Midjourney slightly changes the objects' position in the center when zooming out. It's recommended to avoid that by carefully selecting the images. It can also be fixed manually before running the script. See [Fix image shift](./guides/fix_image_shift.md)
 - **`Zoom Out 1.5x` button in Midjourney is currently bugged and uses another zoom factor than `--zoom 1.5` prompt argument. To create an animation from images created with this button, use `-z 1.3333` argument for the script.**
 
-
 ## Tips on editing the images
 
-The script stacks images on top of each other and blends them together. 
-The most zoomed-in images are always on top of less zoomed-in images, 
+The script stacks images on top of each other and blends them together.
+The most zoomed-in images are always on top of less zoomed-in images,
 so if you want to modify something on the images manually, you can do it only on the most zoomed-in image.
 
-
 ## Tips on how to generate images with Stable Diffusion or Photoshop
+
 (Thanks to [u/ObiWanCanShowMe](https://www.reddit.com/user/ObiWanCanShowMe/))
 
 ### Stable Diffusion
 
 To create a zoom out image in Stable Diffusion, you can:
+
 1. Create an image.
 2. Outpaint to a multiplier of canvas size (e.g., 2x)
 3. Resize down to the original size.
@@ -156,12 +159,12 @@ Repeat until you get the desired number of images.
 ### Photoshop
 
 You can also create proper images using Photoshop:
+
 1. Create an image.
 2. Resize an image to a multiplier of canvas size (e.g., 2x) and use generative fill on the empty space
 3. Resize down to the original size.
 
 Repeat until you get the desired number of images.
-
 
 ## Animations created with ZoomVideoComposer
 
@@ -171,14 +174,11 @@ Repeat until you get the desired number of images.
 - [Black and white (and 3 more)](https://www.reddit.com/r/midjourney/comments/14x2l6a/zoom_out_animations_collection/)
 - [Platypus at the end of the world (and 2 more)](https://www.reddit.com/r/midjourney/comments/14yv90n/zoom_out_animations_lt35_universe_trip_down_the/)
 
-
 Add your animations here by creating a pull request.
-
 
 ## Projects using ZoomVideoComposer
 
 - [GoAPI Midjourney ZoomVideo Generator](https://huggingface.co/spaces/GoAPI/Midjourney-zoom-video-generator-GoAPI) - creates zoom video from a set of prompts using [GoAPI Midjourney API](https://www.goapi.ai/midjourney-api) to generate images.
-
 
 ## TODOs
 

--- a/helpers.py
+++ b/helpers.py
@@ -251,6 +251,15 @@ def read_images(image_paths, logger, image_engine=DEFAULT_IMAGE_ENGINE):
     return images
 
 
+def save_images(images, output_dir, files_prefix="", start_i=0):
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
+
+    for i, image in enumerate(images):
+        image_path = os.path.join(output_dir, f"{files_prefix}{i + start_i:06d}.png")
+        image.save(image_path)
+
+
 def get_image_paths(input_paths):
     image_paths = []
     for path in input_paths:

--- a/helpers.py
+++ b/helpers.py
@@ -100,6 +100,7 @@ class ImagePIL(ImageWrapper):
 
 # Easing and resampling functions
 
+
 # Gennerat family of power-based easing functions
 def get_ease_pow_in(power, **kwargs):
     return lambda x: pow(x, power)
@@ -118,19 +119,23 @@ def get_ease_pow_in_out(power, **kwargs):
 
 
 # Returns an linear easing function with in and out ease
-# This is useful for very long animations 
+# This is useful for very long animations
 # where you want a steady zoom speed but still start and stop smoothly.
 def get_linear_with_in_out_ease(ease_duration, **kwargs):
     # fraction defines both the x and y of the 'square' in which the easing takes place
     ease_duration_scale = 1 / ease_duration
+
     def linear_ease_in_out(x):
         if x < ease_duration:
             return (x * ease_duration_scale) ** 2 / ease_duration_scale / 2
         elif x > (1 - ease_duration):
             return 1 - ((1 - x) * ease_duration_scale) ** 2 / ease_duration_scale / 2
         else:
-            return (x - ease_duration) * (1 - ease_duration) / (1 - 2 * ease_duration) + ease_duration / 2
-    return linear_ease_in_out      
+            return (x - ease_duration) * (1 - ease_duration) / (
+                1 - 2 * ease_duration
+            ) + ease_duration / 2
+
+    return linear_ease_in_out
 
 
 EASING_FUNCTIONS = {
@@ -152,6 +157,7 @@ EASING_FUNCTIONS = {
 DEFAULT_EASING_KEY = "easeInOutSine"
 DEFAULT_EASING_POWER = 1.5
 DEFAULT_EASE_DURATION = 0.02
+
 
 def get_easing_function(easing, power, ease_duration):
     easing_func = EASING_FUNCTIONS.get(easing, None)
@@ -360,7 +366,7 @@ def create_video_clip(output_path, fps, num_frames, tmp_dir_hash, audio_path, th
         os.path.join(tmp_dir_hash, f"{i:06d}.png") for i in range(num_frames)
     ]
     video_clip = ImageSequenceClip(image_files, fps=fps)
-    video_write_kwargs = {"codec": "libx264", "threads": threads}
+    video_write_kwargs = {"codec": "libx264", "threads": threads, "bitrate": "8M"}
 
     # Add audio
     if audio_path:

--- a/helpers.py
+++ b/helpers.py
@@ -366,7 +366,7 @@ def create_video_clip(output_path, fps, num_frames, tmp_dir_hash, audio_path, th
         os.path.join(tmp_dir_hash, f"{i:06d}.png") for i in range(num_frames)
     ]
     video_clip = ImageSequenceClip(image_files, fps=fps)
-    video_write_kwargs = {"codec": "libx264", "threads": threads, "bitrate": "8M"}
+    video_write_kwargs = {"codec": "libx264", "threads": threads}
 
     # Add audio
     if audio_path:

--- a/zoom_video_composer.py
+++ b/zoom_video_composer.py
@@ -205,7 +205,7 @@ VERSION = "0.3.2"
     "--blend-images-only",
     is_flag=True,
     default=False,
-    help="Stops after blending the images. Inspecting the blend images is useful to inspect any image-shifts or other artefacts before generating the video.",
+    help="Stops after blending the images. Inspecting the blend images is useful to detect any image-shifts or other artefacts before generating the video.",
     show_default=True,
 )
 def zoom_video_composer_cli(


### PR DESCRIPTION
Adds an option '--blend-images-only' to inspect the blended images before generating the video.

Any artefact that slips into the blend images due to:
- image shift
- too aggressive region variation
- 
can be more easily (and faster) spotted in the blended images than in the generated video.

Having this option makes it faster and easier to resolve any issues in the images before generating the movie.

PS: my auto-formatter formatted some lines without any changes